### PR TITLE
build : Remove redundant tag stage

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,6 @@ function sendTG() {
 sendTG "\`Docker image is being pushed!\`"
 
 docker build . -t harukanetwork/evolutionx-ota-ci:latest
-docker tag harukanetwork/evolutionx-ota-ci:latest harukanetwork/evolutionx-ota-ci:latest
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 docker push harukanetwork/evolutionx-ota-ci
 


### PR DESCRIPTION
The image is already tagged in the build stage, remove the redundant docker tag stage.